### PR TITLE
Allow removing per-target settings

### DIFF
--- a/lib/project_helper.rb
+++ b/lib/project_helper.rb
@@ -44,7 +44,10 @@ class ProjectHelper
       options = shared_target_options[target.to_s]
       if options
         @project.build_configurations.each do |configuration|
-          target.build_configuration_list.build_settings(configuration.to_s).merge!(options)
+          options.each do |key, value|
+            target.build_configuration_list.build_settings(configuration.to_s)[key] = value
+            target.build_configuration_list.build_settings(configuration.to_s).delete(key) if value == nil
+          end
         end
       end
     end


### PR DESCRIPTION
If you set a target setting to nil it will be removed.  This follows the same pattern used by ambient for per-scheme settings.